### PR TITLE
fix entrypoint context directory

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,10 @@ jobs:
             ${{ steps.meta.outputs.tags }} & \
           (
             sleep 10 && \
-            if [[ $(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:8080) -ne 200 ]]; then
+            if [[ $(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:8080/apis/pet-api.json) -ne 200 ]]; then
+              exit 1;
+            fi && \
+            if [[ $(curl -o /dev/null -s -w "%{http_code}\n" http://localhost:8080/apis/store-api.json) -ne 200 ]]; then
               exit 1;
             fi && \
             docker container stop swagger-ui-test

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ docker run \
   -p 80:8080 \
   -e POLL_INTERVAL_SECONDS=60 \
   -e POLL_URL=https://raw.githubusercontent.com/bbortt/swagger-ui-demo/master/swagger-config.json \
-  postfinance/polling-swagger-ui:1.0.0
+  postfinance/polling-swagger-ui:$RELEASE_VERSION
 ```
 
 # Contributing

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 #
 # Docker entrypoint starting nginx as well as the polling process.
-# Original CMD ["sh", "/usr/share/nginx/run.sh"]: https://github.com/swagger-api/swagger-ui/blob/master/Dockerfile.
+# Original CMD ["nginx", "-g", "daemon off;"]: https://github.com/swagger-api/swagger-ui/blob/master/Dockerfile.
 
-/appl/polling-swagger-ui/poll-monitor.sh & /docker-entrypoint.sh sh -c "nginx -g \"daemon off;\""
+/appl/polling-swagger-ui/poll-monitor.sh & /docker-entrypoint.sh nginx -g "daemon off;"


### PR DESCRIPTION
apparently the `sh -c` does create an invalid context for `nginx`. it is required to call it directly!